### PR TITLE
Solve 3 period OG time path

### DIFF
--- a/OverlappingGenerations/3PeriodModel/SS.py
+++ b/OverlappingGenerations/3PeriodModel/SS.py
@@ -19,13 +19,15 @@ def solve_ss(r_init, params):
         # get w
         w = firm.get_w(r, alpha, A, delta)
         # solve HH problem
-        foc_args = (beta, sigma, r, w, n)
+        foc_args = (beta, sigma, r, w, n, 0.0)
         b_sp1_guess = [0.05, 0.05]
         result = opt.root(hh.FOCs, b_sp1_guess, args=foc_args)
         b_sp1 = result.x
+        euler_errors = result.fun
+        b_s = np.append(0.0, b_sp1)
         # use market clearing
         L = agg.get_L(n)
-        K = agg.get_K(b_sp1)
+        K = agg.get_K(b_s)
         # find implied r
         r_prime = firm.get_r(L, K, alpha, A, delta)
         # check distance
@@ -37,4 +39,4 @@ def solve_ss(r_init, params):
         # update iteration counter
         ss_iter += 1
 
-    return r
+    return r, b_sp1, euler_errors

--- a/OverlappingGenerations/3PeriodModel/TPI.py
+++ b/OverlappingGenerations/3PeriodModel/TPI.py
@@ -1,0 +1,64 @@
+import numpy as np
+import scipy.optimize as opt
+import firm
+import households as hh
+import aggregates as agg
+
+
+def solve_tp(r_path_init, params):
+    '''
+    Solves for the time path equlibrium using TPI
+    '''
+    (beta, sigma, n, alpha, A, delta, T, xi, b_sp1_pre, r_ss,
+     b_sp1_ss) = params
+    tpi_dist = 7.0
+    tpi_tol = 1e-8
+    tpi_iter = 0
+    tpi_max_iter = 300
+    r_path = np.append(r_path_init, np.ones(2) * r_ss)
+    while (tpi_dist > tpi_tol) & (tpi_iter < tpi_max_iter):
+        w_path = firm.get_w(r_path, alpha, A, delta)
+        # Solve HH problem
+        b_sp1_mat = np.zeros((T + 2, 2))
+        euler_errors_mat = np.zeros((T + 2, 2))
+        # solve upper right corner
+        foc_args = (beta, sigma, r_path[:2], w_path[:2], n[-2:],
+                    b_sp1_pre[0])
+        b_sp1_guess = b_sp1_ss[-1]
+        result = opt.root(hh.FOCs, b_sp1_guess, args=foc_args)
+        b_sp1_mat[0, -1] = result.x
+        euler_errors_mat[0, -1] = result.fun
+        # solve all full lifetimes
+        DiagMaskb = np.eye(2, dtype=bool)
+        for t in range(T):
+            foc_args = (beta, sigma, r_path[t:t+3], w_path[t:t+3], n,
+                        0.0)
+            b_sp1_guess = b_sp1_ss
+            result = opt.root(hh.FOCs, b_sp1_guess, args=foc_args)
+            b_sp1_mat[t:t+2, :] = (DiagMaskb * result.x +
+                                   b_sp1_mat[t:t+2, :])
+            euler_errors_mat[t:t+2, :] = (
+                DiagMaskb * result.fun + euler_errors_mat[t:t+2, :])
+        # create a b_s_mat
+        b_s_mat = np.zeros((T, 3))
+        b_s_mat[0, 1:] = b_sp1_pre
+        b_s_mat[1:, 1:] = b_sp1_mat[:T-1, :]
+        # use market clearing
+        L_path = np.ones(T) * agg.get_L(n)
+        K_path = agg.get_K(b_s_mat)
+        # find implied r
+        r_path_prime = firm.get_r(L_path, K_path, alpha, A, delta)
+        # check distance
+        tpi_dist = np.absolute(r_path[:T] - r_path_prime[:T]).max()
+        print('Iteration = ', tpi_iter, ', Distance = ', tpi_dist)
+        # update r
+        r_path[:T] = xi * r_path_prime[:T] + (1 - xi) * r_path[:T]
+        # update iteration counter
+        tpi_iter += 1
+
+    if tpi_iter < tpi_max_iter:
+        print('The time path solved')
+    else:
+        print('The time path did not solve')
+
+    return r_path[:T], euler_errors_mat[:T, :]

--- a/OverlappingGenerations/3PeriodModel/aggregates.py
+++ b/OverlappingGenerations/3PeriodModel/aggregates.py
@@ -10,10 +10,12 @@ def get_L(n):
     return L
 
 
-def get_K(b_sp1):
+def get_K(b_s):
     '''
     Find aggregate capital supply
     '''
-    K = b_sp1.sum()
-
+    if b_s.ndim == 1:
+        K = b_s.sum()
+    if b_s.ndim == 2:
+        K = b_s.sum(axis=1)
     return K

--- a/OverlappingGenerations/3PeriodModel/execute.py
+++ b/OverlappingGenerations/3PeriodModel/execute.py
@@ -1,6 +1,8 @@
 # import packages
 import numpy as np
+import matplotlib.pyplot as plt
 import SS
+import TPI
 
 # set model parameters
 sigma = 1.5  # CRRA
@@ -8,6 +10,7 @@ beta = 0.8  # discount rate
 alpha = 0.3   # capital share of output
 delta = 0.1  # rate of depreciation
 A = 1.0  # TFP
+T = 20  # number of periods until SS
 
 # exogenous labor supply
 n = np.array([1.0, 1.0, 0.2])
@@ -17,6 +20,23 @@ xi = 0.1
 # solve the SS
 ss_params = (beta, sigma, n, alpha, A, delta, xi)
 r_init = 1 / beta - 1
-r_ss = SS.solve_ss(r_init, ss_params)
+r_ss, b_sp1_ss, euler_errors_ss = SS.solve_ss(r_init, ss_params)
+print('SS interest rate is ', r_ss)
+print('Maximum Euler error in the SS is ',
+      np.absolute(euler_errors_ss).max())
 
 # solve the time path
+r_path_init = np.ones(T) * r_ss
+b_sp1_pre = 1.1 * b_sp1_ss  # initial distribiton of savings -
+# determined before t=1
+# NOTE: if the initial distribution of savings is the same as the SS
+# value, then the path of interest rates should equal the SS value in
+# each period...
+tpi_params = (beta, sigma, n, alpha, A, delta, T, xi, b_sp1_pre, r_ss,
+              b_sp1_ss)
+r_path, euler_errors_path = TPI.solve_tp(r_path_init, tpi_params)
+print('Maximum Euler error along the time path is ',
+      np.absolute(euler_errors_path).max())
+plt.plot(np.arange(T), r_path)
+plt.title("Path of real interest rates")
+plt.show()

--- a/OverlappingGenerations/3PeriodModel/households.py
+++ b/OverlappingGenerations/3PeriodModel/households.py
@@ -9,18 +9,14 @@ def FOCs(b_sp1, *args):
     (1) u'(c1) = beta * (1 + r)* u'(c2) -> b2
     (2) u'(c2) = beta * (1 + r)* u'(c3) -> b3
     '''
-    beta, sigma, r, w, n = args
-    b_s = np.append([0], b_sp1)
-    c1 = get_c(r, w, n[0], b_s[0], b_sp1[0])
-    c2 = get_c(r, w, n[1], b_s[1], b_sp1[1])
-    c3 = get_c(r, w, n[2], b_s[2], 0)
-    mu_c1 = u_prime(c1, sigma)
-    mu_c2 = u_prime(c2, sigma)
-    mu_c3 = u_prime(c3, sigma)
-    error1 = mu_c1 - beta * (1+r) * mu_c2
-    error2 = mu_c2 - beta * (1+r) * mu_c3
-    foc_errors = [error1, error2]
-
+    beta, sigma, r, w, n, b_init = args
+    b_s = np.append(b_init, b_sp1)
+    b_sp1 = np.append(b_sp1, 0.0)
+    c = get_c(r, w, n, b_s, b_sp1)
+    mu_c = u_prime(c, sigma)
+    lhs_euler = mu_c
+    rhs_euler = beta * (1+r) * mu_c
+    foc_errors = lhs_euler[:-1] - rhs_euler[1:]
     return foc_errors
 
 

--- a/OverlappingGenerations/3PeriodModel/tests/test_firm.py
+++ b/OverlappingGenerations/3PeriodModel/tests/test_firm.py
@@ -1,0 +1,31 @@
+import numpy as np
+import firm
+
+
+def test_get_r():
+    '''
+    Teset of the firm.get_r() function
+    '''
+    A = 1.0
+    alpha = 0.5
+    delta = 0.1
+    L = 4.0
+    K = 16.0
+    expected_value = 0.15
+    test_value = firm.get_r(L, K, alpha, A, delta)
+
+    assert np.allclose(test_value, expected_value)
+
+
+def test_get_w():
+    '''
+    Teset of the firm.get_w() function
+    '''
+    A = 1.0
+    alpha = 0.25
+    delta = 0.05
+    r = 0.05
+    expected_value = 1.01790660622309
+    test_value = firm.get_w(r, alpha, A, delta)
+
+    assert np.allclose(test_value, expected_value)


### PR DESCRIPTION
This PR added the updated 3 period OG model scripts that will solve for the time path.

Note these also now give an example of how to find and store the euler errors (to check that you are satisfying the FOCs) and an example of how to plot some output.

Finally, another test script example is added, with tests of the firm module in `test_firm.py`.